### PR TITLE
WIP: added access to auth context

### DIFF
--- a/src/components/file/useFile.js
+++ b/src/components/file/useFile.js
@@ -7,7 +7,7 @@ import {
   getContentFromFile, saveFile, ensureFile, deleteFile,
 } from './helpers';
 import {
-  FileCard, FileForm, useBlob, RepositoryContext,
+  FileCard, FileForm, useBlob, RepositoryContext, AuthenticationContext,
 } from '..';
 
 function useFile({
@@ -22,6 +22,8 @@ function useFile({
   const [file, setFile] = useState();
   const [blob, setBlob] = useState();
   const { actions: repositoryActions } = useContext(RepositoryContext);
+  const { state: contextAuthentication, config: contextConfig } = useContext(AuthenticationContext);
+
   const branch = repository && (repository.branch || repository.default_branch);
 
   const [deleted, setDeleted] = useState();
@@ -117,6 +119,7 @@ function useFile({
     if (!repository && file) {
       close();
     }
+    if (!contextAuthentication)  close();
   }, [repository, file, close]);
 
   useEffect(() => {


### PR DESCRIPTION
Needs to be reviewed/tested. This fix addresses the issue by:
- adding access to authentication context within `useFile` custom hook
- this access is used to force a `close()` on the file when the authentication context is null/undefined
```
    if (!contextAuthentication)  close();
```
This is inside a `useEffect` that already does a similar close if there is no repository defined.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/gitea-react-toolkit/43)
<!-- Reviewable:end -->
