### PR TITLE
Added prop to allow hiding the RepositoryMenu from ApplicationBar

### DIFF
--- a/src/components/application-bar/ApplicationBar.js
+++ b/src/components/application-bar/ApplicationBar.js
@@ -19,6 +19,7 @@ function ApplicationBar({
   buttons,
   drawerMenu,
   drawerMenuProps,
+  hideRepositoryMenu,
 }) {
   const classes = useStyles();
   const { state: file } = useContext(FileContext)
@@ -43,7 +44,7 @@ function ApplicationBar({
           </Typography>
           <div className={classes.grow} />
           {buttons}
-          <RepositoryMenu />
+          {!hideRepositoryMenu ? <RepositoryMenu /> : null}
           <UserMenu />
         </Toolbar>
       </AppBar>
@@ -53,6 +54,7 @@ function ApplicationBar({
 
 ApplicationBar.defaultProps = {
   drawerMenuProps: {},
+  hideRepositoryMenu: false,
 };
 
 ApplicationBar.propTypes = {


### PR DESCRIPTION
- [ ] Open https://deploy-preview-83--gitea-react-toolkit.netlify.app/#/Application%20Bar%20?id=applicationbar
- [ ] Scroll to `view code` and add `hideRepositoryMenu` to `ApplicationBar`
```js
   <ApplicationBar
      hideRepositoryMenu
      title='Application Title'
      buttons={buttons}
      drawerMenu={drawerMenu}
    />
```
- [ ] The RepositoryMenu (Folder Icon) should disappear 


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/gitea-react-toolkit/83)
<!-- Reviewable:end -->
