### PR TITLE
Feature  130/improve http error handling and add checking for network connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.7.0",
+  "version": "1.7.0-alpha.2",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.7.0-alpha",
+  "version": "1.7.0",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.6.4-alpha",
+  "version": "1.7.0-alpha",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.7.0-alpha.2",
+  "version": "1.7.0",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.6.3",
+  "version": "1.6.4-alpha",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/src/components/authentication/Authentication.context.js
+++ b/src/components/authentication/Authentication.context.js
@@ -13,11 +13,18 @@ export function AuthenticationContextProvider({
   loadAuthentication,
   saveAuthentication,
   children,
+  onError,
 }) {
   const {
     state, actions, component, config,
   } = useAuthentication({
-    authentication, onAuthentication, config: _config, messages, loadAuthentication, saveAuthentication,
+    authentication,
+    onAuthentication,
+    config: _config,
+    messages,
+    loadAuthentication,
+    saveAuthentication,
+    onError,
   });
   const context = {
     state,
@@ -61,4 +68,6 @@ AuthenticationContextProvider.propTypes = {
   saveAuthentication: PropTypes.func,
   /** Callback function to retrieve persisted authentication. */
   loadAuthentication: PropTypes.func,
+  /** optional callback for error */
+  onError: PropTypes.func,
 };

--- a/src/components/authentication/useAuthentication.js
+++ b/src/components/authentication/useAuthentication.js
@@ -4,7 +4,11 @@ import React, {
 import PropTypes from 'prop-types';
 import deepFreeze from 'deep-freeze';
 import {
-  authenticate, defaultErrorMessages, ERROR_SERVER_UNREACHABLE, ERROR_NETWORK_DISCONNECTED,
+  authenticate,
+  defaultErrorMessages,
+  parseError,
+  ERROR_SERVER_UNREACHABLE,
+  ERROR_NETWORK_DISCONNECTED,
 } from '../../core';
 import { LoginForm } from '.';
 
@@ -15,6 +19,7 @@ function useAuthentication({
   config,
   loadAuthentication,
   saveAuthentication,
+  onError,
 }) {
   const authentication = _authentication && deepFreeze(_authentication);
 
@@ -93,6 +98,7 @@ function useAuthentication({
       const friendlyError = parseError(e);
 
       setError(friendlyError.errorMessage);
+      onError && onError(friendlyError)
     }
   }, [
     config, logout, update,
@@ -162,6 +168,8 @@ useAuthentication.propTypes = {
   saveAuthentication: PropTypes.func,
   /** Callback function to retrieve persisted authentication. */
   loadAuthentication: PropTypes.func,
+  /** Callback function on error. */
+  onError: PropTypes.func,
 };
 
 export default useAuthentication;

--- a/src/core/gitea-api/authentication.ts
+++ b/src/core/gitea-api/authentication.ts
@@ -67,9 +67,13 @@ export const authenticate: Authenticate = async ({
 
   if (username && password) {
     let authHeaders = authorizationHeaders({ username, password });
-    _config = { ...config, headers: { ...config.headers, ...authHeaders } };
-    user = await getUser({ username, config: _config, noCache: true });
-    token = await ensureToken({ username, config: _config, noCache: true });
+    _config = {
+        ...config,
+        headers: { ...config.headers, ...authHeaders },
+        noCache: true,
+    };
+    user = await getUser({ username, config: _config });
+    token = await ensureToken({ username, config: _config });
     authHeaders = authorizationHeaders({ token });
     _config = { ...config, headers: { ...config.headers, ...authHeaders } };
   }

--- a/src/core/gitea-api/authentication.ts
+++ b/src/core/gitea-api/authentication.ts
@@ -68,8 +68,8 @@ export const authenticate: Authenticate = async ({
   if (username && password) {
     let authHeaders = authorizationHeaders({ username, password });
     _config = { ...config, headers: { ...config.headers, ...authHeaders } };
-    user = await getUser({ username, config: _config });
-    token = await ensureToken({ username, config: _config });
+    user = await getUser({ username, config: _config, noCache: true });
+    token = await ensureToken({ username, config: _config, noCache: true });
     authHeaders = authorizationHeaders({ token });
     _config = { ...config, headers: { ...config.headers, ...authHeaders } };
   }

--- a/src/core/gitea-api/http/http.d.ts
+++ b/src/core/gitea-api/http/http.d.ts
@@ -7,6 +7,7 @@ export interface APIConfig {
   tokenid?: string;
   headers?: object;
   token?: string | TokenConfigWithHeaders;
+  noCache?: boolean;
 }
 
 export interface CoreOptions {

--- a/src/core/gitea-api/http/http.ts
+++ b/src/core/gitea-api/http/http.ts
@@ -103,7 +103,7 @@ export const get = async ({
   let response: any;
 
   try {
-    if (noCache || config.noCache) {
+    if (noCache || config.noCache) { // also check config for noCache
       const _params = { noCache: Math.random(), ...params };
       response = await axios.get(url, { ..._config, params: _params });
     } else {

--- a/src/core/gitea-api/http/http.ts
+++ b/src/core/gitea-api/http/http.ts
@@ -62,6 +62,7 @@ interface Get {
   url: string;
   params?: object;
   noCache?: number | boolean;
+  fullResponse?: boolean;
 }
 
 export const checkIfServerOnline = async (serverUrl): Promise<void> => {
@@ -87,8 +88,16 @@ export const checkIfServerOnline = async (serverUrl): Promise<void> => {
   };
 };
 
+/**
+ * do http get
+ * @param {string} url
+ * @param {object} params
+ * @param {object} config - config parameters
+ * @param {boolean} [noCache] optional flag to disable caching
+ * @param {boolean} [fullResponse] optional flag to return full response, useful if you want specifics such as http codes
+ */
 export const get = async ({
-  url, params, config, noCache,
+  url, params, config, noCache, fullResponse,
 }: Get): Promise<any> => {
   const _config = config ? extendConfig(config) : {};
   let response: any;
@@ -104,6 +113,9 @@ export const get = async ({
     await checkIfServerOnline(config.server);
   }
 
+  if (fullResponse) {
+      return response;
+  }
   const data = response ? response.data : null;
   return data;
 };

--- a/src/core/gitea-api/http/http.ts
+++ b/src/core/gitea-api/http/http.ts
@@ -94,7 +94,7 @@ export const checkIfServerOnline = async (serverUrl): Promise<void> => {
  * @param {object} params
  * @param {object} config - config parameters
  * @param {boolean} [noCache] optional flag to disable caching
- * @param {boolean} [fullResponse] optional flag to return full response, useful if you want specifics such as http codes
+ * @param {boolean} [fullResponse] optional flag to return full http response, useful if you want specifics such as http codes
  */
 export const get = async ({
   url, params, config, noCache, fullResponse,

--- a/src/core/gitea-api/http/http.ts
+++ b/src/core/gitea-api/http/http.ts
@@ -114,7 +114,7 @@ export const get = async ({
   }
 
   if (fullResponse) {
-      return response;
+    return response;
   }
   const data = response ? response.data : null;
   return data;

--- a/src/core/gitea-api/http/http.ts
+++ b/src/core/gitea-api/http/http.ts
@@ -85,7 +85,7 @@ export const checkIfServerOnline = async (serverUrl): Promise<void> => {
     } else {
       throw e;
     }
-  };
+  }
 };
 
 /**
@@ -94,7 +94,7 @@ export const checkIfServerOnline = async (serverUrl): Promise<void> => {
  * @param {object} params
  * @param {object} config - config parameters
  * @param {boolean} [noCache] optional flag to disable caching
- * @param {boolean} [fullResponse] optional flag to return full http response, useful if you want specifics such as http codes
+ * @param {boolean} [fullResponse] optional flag to return full http response including data and statusCode, useful if you want specifics such as http codes
  */
 export const get = async ({
   url, params, config, noCache, fullResponse,
@@ -103,7 +103,7 @@ export const get = async ({
   let response: any;
 
   try {
-    if (noCache) {
+    if (noCache || config.noCache) {
       const _params = { noCache: Math.random(), ...params };
       response = await axios.get(url, { ..._config, params: _params });
     } else {

--- a/src/core/gitea-api/http/http.ts
+++ b/src/core/gitea-api/http/http.ts
@@ -92,7 +92,7 @@ export const checkIfServerOnline = async (serverUrl): Promise<void> => {
  * do http get
  * @param {string} url
  * @param {object} params
- * @param {object} config - config parameters
+ * @param {APIConfig|ExtendConfig} config - config parameters
  * @param {boolean} [noCache] optional flag to disable caching
  * @param {boolean} [fullResponse] optional flag to return full http response including data and statusCode, useful if you want specifics such as http codes
  */

--- a/src/core/gitea-api/users/tokens.ts
+++ b/src/core/gitea-api/users/tokens.ts
@@ -19,16 +19,16 @@ export interface TokenConfigWithHeaders {
 }
 
 interface GetTokens {
-  (args: { username: string; config: TokenConfig, noCache: boolean }): Promise<AuthToken[]>;
+  (args: { username: string; config: TokenConfig }): Promise<AuthToken[]>;
 }
 
 // requires config.headers with authorization
-export const getTokens: GetTokens = async ({ username, config, noCache }) => {
+export const getTokens: GetTokens = async ({ username, config }) => {
   let tokens;
   const url = Path.join(apiPath, 'users', username, 'tokens');
 
   try {
-    tokens = await get({ url, config, noCache });
+    tokens = await get({ url, config });
   } catch {
     tokens = null;
   }
@@ -36,7 +36,7 @@ export const getTokens: GetTokens = async ({ username, config, noCache }) => {
 };
 
 interface CreateToken {
-  (args: { username: string; config: TokenConfigWithHeaders, noCache: boolean }): Promise<AuthToken[]>;
+  (args: { username: string; config: TokenConfigWithHeaders }): Promise<AuthToken[]>;
 }
 
 // requires config.headers with authorization
@@ -80,8 +80,8 @@ export const deleteToken: DeleteToken = async ({
 
 
 // requires config.headers with authorization
-export const ensureToken: CreateToken = async ({ username, config, noCache }) => {
-  const tokens = await getTokens({ username, config, noCache });
+export const ensureToken: CreateToken = async ({ username, config }) => {
+  const tokens = await getTokens({ username, config });
 
   if (tokens) {
     const tokenMatches = tokens.filter(_token => _token.name === config.tokenid);

--- a/src/core/gitea-api/users/tokens.ts
+++ b/src/core/gitea-api/users/tokens.ts
@@ -19,16 +19,16 @@ export interface TokenConfigWithHeaders {
 }
 
 interface GetTokens {
-  (args: { username: string; config: TokenConfig }): Promise<AuthToken[]>;
+  (args: { username: string; config: TokenConfig, noCache: boolean }): Promise<AuthToken[]>;
 }
 
 // requires config.headers with authorization
-export const getTokens: GetTokens = async ({ username, config }) => {
+export const getTokens: GetTokens = async ({ username, config, noCache }) => {
   let tokens;
   const url = Path.join(apiPath, 'users', username, 'tokens');
 
   try {
-    tokens = await get({ url, config });
+    tokens = await get({ url, config, noCache });
   } catch {
     tokens = null;
   }
@@ -36,7 +36,7 @@ export const getTokens: GetTokens = async ({ username, config }) => {
 };
 
 interface CreateToken {
-  (args: { username: string; config: TokenConfigWithHeaders }): Promise<AuthToken[]>;
+  (args: { username: string; config: TokenConfigWithHeaders, noCache: boolean }): Promise<AuthToken[]>;
 }
 
 // requires config.headers with authorization
@@ -80,8 +80,8 @@ export const deleteToken: DeleteToken = async ({
 
 
 // requires config.headers with authorization
-export const ensureToken: CreateToken = async ({ username, config }) => {
-  const tokens = await getTokens({ username, config });
+export const ensureToken: CreateToken = async ({ username, config, noCache }) => {
+  const tokens = await getTokens({ username, config, noCache });
 
   if (tokens) {
     const tokenMatches = tokens.filter(_token => _token.name === config.tokenid);

--- a/src/core/gitea-api/users/users.ts
+++ b/src/core/gitea-api/users/users.ts
@@ -4,15 +4,16 @@ import {
   apiPath, get, ERROR_SERVER_UNREACHABLE, ERROR_NETWORK_DISCONNECTED,
 } from '../http/http';
 
-export const getUser = async ({ username, config }: {
+export const getUser = async ({ username, config, noCache }: {
   username: string;
   config: APIConfig;
+  noCache: boolean;
 }): Promise<{ id: object } | null> => {
   let user = null;
   const url = Path.join(apiPath, 'users', username);
 
   try {
-    user = await get({ url, config });
+    user = await get({ url, config, noCache });
   } catch (e) {
     const errorMessage = e && e.message ? e.message : '';
 

--- a/src/core/gitea-api/users/users.ts
+++ b/src/core/gitea-api/users/users.ts
@@ -4,16 +4,15 @@ import {
   apiPath, get, ERROR_SERVER_UNREACHABLE, ERROR_NETWORK_DISCONNECTED,
 } from '../http/http';
 
-export const getUser = async ({ username, config, noCache }: {
+export const getUser = async ({ username, config }: {
   username: string;
   config: APIConfig;
-  noCache: boolean;
 }): Promise<{ id: object } | null> => {
   let user = null;
   const url = Path.join(apiPath, 'users', username);
 
   try {
-    user = await get({ url, config, noCache });
+    user = await get({ url, config });
   } catch (e) {
     const errorMessage = e && e.message ? e.message : '';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -11098,14 +11098,15 @@ markdown-to-jsx@^6.10.3:
     prop-types "^15.6.2"
     unquote "^1.1.0"
 
-markdown-translatable@1.2.12:
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/markdown-translatable/-/markdown-translatable-1.2.12.tgz#f4100e7d5306e939c2190edcf1868c0e316a36d0"
-  integrity sha512-HvS2kpEan1mWpUBEUq1xv0PfETg6dJBlgrUBaXOO4qO7B1lq+jb1Tm806pK0f0mQrmAB6c89+HB9XRsPXCWPyw==
+markdown-translatable@1.2.16:
+  version "1.2.16"
+  resolved "https://registry.yarnpkg.com/markdown-translatable/-/markdown-translatable-1.2.16.tgz#048624bb4762370db30030c4d0265b721c54f7e8"
+  integrity sha512-miTzfgoCCFwodkNN9EuUlGg2HoKZbJlYt1BqbqsfpT2jbXbu7jMPVB4d+Jj7wh3wyNSJzON4GqV4X90ke6Gt1w==
   dependencies:
     deep-freeze "^0.0.1"
     md5 "^2.2.1"
     prop-types "^15.7.2"
+    react-headroom "^3.1.0"
     react-markdown "4.0.6"
     showdown "^1.9.1"
     turndown "^7.0.0"
@@ -13801,7 +13802,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@15.7.2, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -13986,7 +13987,7 @@ qw@~1.0.1:
   resolved "https://registry.yarnpkg.com/qw/-/qw-1.0.1.tgz#efbfdc740f9ad054304426acb183412cc8b996d4"
   integrity sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=
 
-raf@^3.4.1:
+raf@^3.3.0, raf@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
   integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
@@ -14162,6 +14163,15 @@ react-group@^3.0.2:
   integrity sha512-0Jy99MD27jHSJ0PeynomUM0WArxywdcqQUKLttBWV6KYH+zlKWT/RhDwVxrODtMkRxf644BzuJFie1Hvfun7jA==
   dependencies:
     prop-types "^15.7.2"
+
+react-headroom@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-headroom/-/react-headroom-3.1.1.tgz#573a7bd87ce0eda70bcf0588e86e0d461280fe95"
+  integrity sha512-mmZA8o1pItF1py4XlYPQD4QpyrTzIuafYjrB/RrJKGPiWEz8IyUcfxoZiiw6qz3oOylLs5SWesCJINA4uThQYw==
+  dependencies:
+    prop-types "^15.5.8"
+    raf "^3.3.0"
+    shallowequal "^1.1.0"
 
 react-icons@^3.8.0:
   version "3.11.0"
@@ -15371,6 +15381,11 @@ shallow-clone@^3.0.0:
   integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
   dependencies:
     kind-of "^6.0.2"
+
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shasum-object@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Describe what your pull request addresses
- part of https://github.com/unfoldingword/gateway-edit/issues/130
- added support for noCache to config for http get
- changed authenticate() to use noCache
- added optional onError callback for AuthenticationContextProvider

## Test Instructions
- [ ] test with https://deploy-preview-196--gateway-edit.netlify.app/
- with PC network connected:
  - [ ] launch app
  - [ ] login
  - [ ] in account settings change org to test_org language to cmn-x-omc_, and click save and continue
  - [ ] should see warning that GLT could not be found:
  
![Screen Shot 2021-05-12 at 1 20 08 PM](https://user-images.githubusercontent.com/14238574/118030593-8326e380-b333-11eb-935b-47bc1bdb7f92.png)

  - [ ] click send feedback
  - [ ] fill out bug reports - I just used `t` for all text fields (so email would be invalid)
  - [ ] click submit and should see error:
  
![Screen Shot 2021-05-12 at 1 26 32 PM](https://user-images.githubusercontent.com/14238574/118030729-ad78a100-b333-11eb-8a53-a61906fcdda5.png)

  - [ ] click close
  - [ ] fill out bug reports - this time I just used `test@test.com` for all text fields
  - [ ] this time it should succeed

- disconnect PC from network (with WIFI connection it's easy to disable  WIFI for testing)
  - [ ] click submit and this time should see Network error:

![Screen Shot 2021-05-12 at 1 29 34 PM](https://user-images.githubusercontent.com/14238574/118034387-eca8f100-b337-11eb-8777-ba142563724d.png)

  - [ ] click close to close network error dialog
  - [ ] in drawer select logout
  - [ ] try to log in and should see error popup:

![Screen Shot 2021-05-12 at 2 15 48 PM](https://user-images.githubusercontent.com/14238574/118035329-11519880-b339-11eb-9f8e-a95463bb67ea.png)


- connect to PC network
  - [ ] once network shows connected, click close
  - [ ] try to login and it should succeed
  - [ ] should take you back to feedback page.  click X to close
  - [ ] should take to resource page and see the invalid resource prompt again:

![Screen Shot 2021-05-12 at 1 20 08 PM](https://user-images.githubusercontent.com/14238574/118035895-da2fb700-b339-11eb-819b-6f25ef7231a4.png)


  - [ ] click cancel
  - [ ] go to account settings and select en as language.  Click save and continue and should not see error.

- disconnect PC from network
  - [ ] go to account setup
  - [ ] should eventually see networking error (may need to timeout)


<img width="983" alt="Screen Shot 2021-05-12 at 4 39 26 PM" src="https://user-images.githubusercontent.com/14238574/118041417-c3d92980-b340-11eb-81f9-470750c57152.png">


- connect PC to network
  - [ ] once network shows connected, click retry
  - [ ] this time should be no error and orgs should load


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/gitea-react-toolkit/92)
<!-- Reviewable:end -->

