### PR TITLE
Bugfix/Fixes for long timeouts due to internet disconnects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.8.0-alpha.3",
+  "version": "1.8.0",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.7.0",
+  "version": "1.8.0-alpha.3",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/src/core/gitea-api/http/http.ts
+++ b/src/core/gitea-api/http/http.ts
@@ -74,9 +74,9 @@ interface Get {
  */
 function getServerError(errorMessage, response) {
   const error = new Error(errorMessage);
-  error[ERROR_SERVER_DISCONNECT_ERROR] = true // flag that this error was while checking if server was online
+  error[ERROR_SERVER_DISCONNECT_ERROR] = true; // flag that this error was from checking if server was online
   if (response) { // if we have response, add it
-    error['response'] = response
+    error['response'] = response;
   }
   return error;
 }
@@ -97,9 +97,9 @@ export const checkIfServerOnline = async (serverUrl, config: ExtendConfig= {}): 
     throw getServerError(ERROR_NETWORK_DISCONNECTED, null);
   }
 
-  console.log(`checkIfServerOnline - checking if server responds`) //TODO
   let response;
   try {
+      // checking if server responds
     response = await axios.get(`${serverUrl}/${apiPath}/version`, config);
   } catch (e) {
     const errorMessage = e && e.message ? e.message : '';
@@ -139,9 +139,9 @@ export const get = async ({
     } else {
       response = await api.get(url, { ..._config, params });
     }
-  } catch {
-    console.log(`get - caught exception`)
+  } catch (e) {
     await checkIfServerOnline(config.server, config);
+    response = e?.response; // if server online, return error response
   }
 
   if (fullResponse) {

--- a/src/core/gitea-api/http/http.ts
+++ b/src/core/gitea-api/http/http.ts
@@ -90,10 +90,9 @@ function getServerError(errorMessage, response) {
  *      server was online.
  *
  * @param {string} serverUrl - base path for server (e.g. 'https://git.door43.org')
- * @param {ExtendConfig} config - axios compatible config parameters
+ * @param {ExtendConfig} config - optional axios compatible config parameters
  */
 export const checkIfServerOnline = async (serverUrl, config: ExtendConfig= {}): Promise<void> => {
-  console.log(`checkIfServerOnline - checking for network connection`) //TODO
   if (!navigator.onLine) {
     throw getServerError(ERROR_NETWORK_DISCONNECTED, null);
   }

--- a/src/core/gitea-api/http/http.ts
+++ b/src/core/gitea-api/http/http.ts
@@ -7,6 +7,7 @@ export const apiPath = 'api/v1';
 const DEFAULT_MAX_AGE = 1000;
 const SERVER_ONLINE_STATUS = 200;
 export const ERROR_SERVER_UNREACHABLE = 'ERR_SERVER_UNREACHABLE';
+export const ERROR_SERVER_DISCONNECT_ERROR = 'ERROR_SERVER_DISCONNECT_ERROR';
 export const ERROR_NETWORK_DISCONNECTED = 'ERR_NETWORK_DISCONNECTED';
 export const ERROR_NETWORK_ERROR = 'Network Error';
 
@@ -65,26 +66,55 @@ interface Get {
   fullResponse?: boolean;
 }
 
-export const checkIfServerOnline = async (serverUrl): Promise<void> => {
+/**
+ * create error object from errorMessage and flag that it was from checking network connection status.  Also add http
+ *      response if given
+ * @param {string} errorMessage
+ * @param {object} response - http response
+ */
+function getServerError(errorMessage, response) {
+  const error = new Error(errorMessage);
+  error[ERROR_SERVER_DISCONNECT_ERROR] = true // flag that this error was while checking if server was online
+  if (response) { // if we have response, add it
+    error['response'] = response
+  }
+  return error;
+}
+
+/**
+ * Make sure that we are still connected to the server.  First checks that we are connected to local network.  If not,
+ *      it throws an exception.  If local network is connected it tries to verify that server is up.  If server is
+ *      not up, it throws an exception.
+ *    Note - exception is thrown if error talking to server.  Axios adds response to error.  And we add flag
+ *      ERROR_SERVER_DISCONNECT_ERROR to simplify determining that it was an error checking that server was online.
+ *
+ * @param {string} serverUrl - base path for server (e.g. 'https://git.door43.org')
+ * @param {ExtendConfig} config - axios compatible config parameters
+ */
+export const checkIfServerOnline = async (serverUrl, config: ExtendConfig= {}): Promise<void> => {
+  console.log(`checkIfServerOnline - checking for network connection`) //TODO
   if (!navigator.onLine) {
-    throw new Error(ERROR_NETWORK_DISCONNECTED);
+    throw getServerError(ERROR_NETWORK_DISCONNECTED, null);
   }
 
+  console.log(`checkIfServerOnline - checking if server responds`) //TODO
+  let response;
   try {
-    const response = await axios.get(`${serverUrl}/${apiPath}/version`);
-    const serverIsResponding = response.status === SERVER_ONLINE_STATUS;
-
-    if (!serverIsResponding) {
-      throw new Error(ERROR_SERVER_UNREACHABLE);
-    }
+    response = await axios.get(`${serverUrl}/${apiPath}/version`, config);
   } catch (e) {
     const errorMessage = e && e.message ? e.message : '';
 
     if (errorMessage.match(/network error/ig)) {
-      throw new Error(ERROR_SERVER_UNREACHABLE);
+      throw getServerError(ERROR_SERVER_UNREACHABLE, e?.response);
     } else {
+      e[ERROR_SERVER_DISCONNECT_ERROR] = true // flag that this error was while checking if server was online
       throw e;
     }
+  }
+
+  const serverIsResponding = response?.status === SERVER_ONLINE_STATUS;
+  if (!serverIsResponding) {
+    throw getServerError(ERROR_SERVER_UNREACHABLE, response);
   }
 };
 
@@ -92,7 +122,7 @@ export const checkIfServerOnline = async (serverUrl): Promise<void> => {
  * do http get
  * @param {string} url
  * @param {object} params
- * @param {APIConfig|ExtendConfig} config - config parameters
+ * @param {APIConfig|ExtendConfig} config - axios compatible config parameters
  * @param {boolean} [noCache] optional flag to disable caching
  * @param {boolean} [fullResponse] optional flag to return full http response including data and statusCode, useful if you want specifics such as http codes
  */
@@ -110,7 +140,8 @@ export const get = async ({
       response = await api.get(url, { ..._config, params });
     }
   } catch {
-    await checkIfServerOnline(config.server);
+    console.log(`get - caught exception`)
+    await checkIfServerOnline(config.server, config);
   }
 
   if (fullResponse) {

--- a/src/core/gitea-api/http/http.ts
+++ b/src/core/gitea-api/http/http.ts
@@ -85,8 +85,9 @@ function getServerError(errorMessage, response) {
  * Make sure that we are still connected to the server.  First checks that we are connected to local network.  If not,
  *      it throws an exception.  If local network is connected it tries to verify that server is up.  If server is
  *      not up, it throws an exception.
- *    Note - exception is thrown if error talking to server.  Axios adds response to error.  And we add flag
- *      ERROR_SERVER_DISCONNECT_ERROR to simplify determining that it was an error checking that server was online.
+ *    Note - when axios returns exception, it adds the response to error.  And we add flag
+ *      ERROR_SERVER_DISCONNECT_ERROR to error to simplify determining that it was an error checking that
+ *      server was online.
  *
  * @param {string} serverUrl - base path for server (e.g. 'https://git.door43.org')
  * @param {ExtendConfig} config - axios compatible config parameters
@@ -141,7 +142,9 @@ export const get = async ({
     }
   } catch (e) {
     await checkIfServerOnline(config.server, config);
-    response = e?.response; // if server online, return error response
+    if (fullResponse) {
+      response = e?.response; // if server online, get error response
+    }
   }
 
   if (fullResponse) {


### PR DESCRIPTION
## Describe what your pull request addresses
- part of https://github.com/unfoldingword/gateway-edit/issues/130
- http - added config parameter to checkIfServerOnline and add more info to returned error.

## Test Instructions
- note this is tricky, it is checking for internet disconnects (not WIFI or Ethernet disconnects).  In my setup I have a cable modem connected to a WiFi router, so I have three ways to generate internet disconnects (easiest first):
- test with https://deploy-preview-217--gateway-edit.netlify.app/
  1. unplugging Ethernet cable between cable modem and WIFI router
  2. Using WIFI router admin setup, disable WAN connection
  3. unscrew cable from cable modem (reconnects are very slow due to how long it takes the modem to resync)
- test with https://deploy-preview-207--gateway-edit.netlify.app/
- test network error handling while loading trans helps repos:
  - [ ] launch app and login
  - [ ] set org to `test_org`, and `en`, set to tit 1:4, all panes should be showing content
  - [ ] change language to `ru` (should see everything but tQ since it is not in tsv)
  - test network connection error when loading another book:
    - [ ] unplug internet and change book to `jon`, 
    - [ ] after about 10 sec delay should see popup of network connection error

  <img width="549" alt="Screen Shot 2021-05-20 at 8 59 36 AM" src="https://user-images.githubusercontent.com/14238574/118982872-d7405200-b949-11eb-8f12-4d27d2fa65ff.png">

    - [ ] plug in internet  and click cancel
    - [ ] screens should load, but should see this because there are bad characters in support reference, but since network is connected should not see network disconnected popup:

    <img width="1205" alt="Screen Shot 2021-05-20 at 8 45 45 AM" src="https://user-images.githubusercontent.com/14238574/118981405-4d43b980-b948-11eb-8ad2-631b6f200c40.png">  

  - [ ] change tN to 2 of 5 and tA article should load
- testing network error handling loading helps articles
  - [ ] you should still be at jon 1:1. unplug internet 
  - [ ] change vs to 17 and after about 10 sec should eventually see network error:

  <img width="549" alt="Screen Shot 2021-05-20 at 8 59 36 AM" src="https://user-images.githubusercontent.com/14238574/118982872-d7405200-b949-11eb-8f12-4d27d2fa65ff.png">

  - [ ] plug in internet  and click retry.  Page should reload

- test network error handling while clicking links:
  - [ ] change ref to `tit 1:3`, change tN to 2 of 6.
  - [ ] unplug internet  and click this link on tA:

  <img width="707" alt="Screen Shot 2021-05-20 at 9 08 53 AM" src="https://user-images.githubusercontent.com/14238574/118986970-ce517f80-b94d-11eb-86c5-7878c4111f76.png">

  - [ ] after about 5 sec, should see a load error popup

![Screen Shot 2021-05-27 at 4 17 38 PM](https://user-images.githubusercontent.com/14238574/119892279-fae63800-bf07-11eb-81f2-8d61f6603c87.png)

  - [ ] after another 5 sec, should see a network error popup

  <img width="549" alt="Screen Shot 2021-05-20 at 8 59 36 AM" src="https://user-images.githubusercontent.com/14238574/118987087-efb26b80-b94d-11eb-8918-047453946924.png">

  - [ ] plug in internet , click cancel
  - [ ] click x on this dialog:

![Screen Shot 2021-05-27 at 4 17 38 PM](https://user-images.githubusercontent.com/14238574/119892279-fae63800-bf07-11eb-81f2-8d61f6603c87.png)

  - [ ] change ref to `tit 1:3`, change tN to 2 of 6.
  - [ ] click tA link again and it should load this time

- unplug internet
  - [ ] go to account setup
  - [ ] should eventually see networking error in about 10 sec


- plug in internet
  - [ ] once network shows connected, click retry
  - [ ] this time should be no error and orgs should load

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/gitea-react-toolkit/94)
<!-- Reviewable:end -->
