### PR TITLE
Bugfix/Fix http.get to return error message from non-http errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.8.1-alpha",
+  "version": "1.8.1",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.8.0",
+  "version": "1.8.1-alpha",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/src/core/gitea-api/http/http.ts
+++ b/src/core/gitea-api/http/http.ts
@@ -141,8 +141,16 @@ export const get = async ({
     }
   } catch (e) {
     await checkIfServerOnline(config.server, config);
+    // will arrive here if server is online
     if (fullResponse) {
-      response = e?.response; // if server online, get error response
+      if (e?.response) { // if http error, get response
+        response = e?.response;
+      } else { // this is not http error, so get what we can from exception
+        response = {
+            statusText: e?.toString(),
+            status: 1,
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Describe what your pull request addresses
- part of https://github.com/unfoldingword/gateway-edit/issues/214

- [ ] Fix http.get to return error message from non-http errors

## Test Instructions
- test with https://deploy-preview-233--gateway-edit.netlify.app/
- [ ] run app with test_org, en to make sure app still works

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/gitea-react-toolkit/96)
<!-- Reviewable:end -->
