### PR TITLE
Feature 230/user branch support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.9.2-alpha",
+  "version": "1.9.2",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.9.1",
+  "version": "1.9.2-alpha",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/src/core/gitea-api/http/http.d.ts
+++ b/src/core/gitea-api/http/http.d.ts
@@ -8,6 +8,7 @@ export interface APIConfig {
   headers?: object;
   token?: string | TokenConfigWithHeaders;
   noCache?: boolean;
+  skipNetworkCheck?: boolean;
 }
 
 export interface CoreOptions {

--- a/src/core/gitea-api/http/http.ts
+++ b/src/core/gitea-api/http/http.ts
@@ -140,7 +140,9 @@ export const get = async ({
       response = await api.get(url, { ..._config, params });
     }
   } catch (e) {
-    await checkIfServerOnline(config.server, config);
+    if (!config.skipNetworkCheck) {
+      await checkIfServerOnline(config.server, config);
+    }
     // will arrive here if server is online
     if (fullResponse) {
       if (e?.response) { // if http error, get response


### PR DESCRIPTION
- part of https://github.com/unfoldingword/gateway-edit/issues/230

## Describe what your pull request addresses

- [ ] added optional performance tweak for git  to skip network connection check when there is an error, since that can take up to 10 seconds.

## Test Instructions
- test with https://deploy-preview-257--gateway-edit.netlify.app/
- [ ] open a resource on D43 such as https://git.door43.org/test_org/en_tn
- [ ] edit the readme
- [ ] select "create a new branch..." and name it  with your user name such as: `manny_colon-tc-create-1`
- [ ] click on `propose  file change`
- [ ] open app with test_org and en
- [ ] when everything has loaded, look in the local storage, you should see `manny_colon_resource_card_tn_ref` has switched to `manny_colon-tc-create-1`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/gitea-react-toolkit/99)
<!-- Reviewable:end -->
