### PR TITLE
Feature 228/add support for more urls

### DIFF
--- a/babel.prod.config.js
+++ b/babel.prod.config.js
@@ -1,4 +1,4 @@
-// default build config (used for everything but production)
+// build config for production (on publish)
 module.exports = {
   presets: [
     '@babel/preset-env',
@@ -6,7 +6,6 @@ module.exports = {
     '@babel/preset-typescript',
   ],
   plugins: [
-  'istanbul',
   '@babel/plugin-proposal-nullish-coalescing-operator',
   '@babel/plugin-proposal-optional-chaining',
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.10.0-rc.20",
+  "version": "1.10.1-alpha",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",
@@ -24,7 +24,7 @@
   "scripts": {
     "start": "styleguidist server",
     "build": "styleguidist build",
-    "prepublishOnly": "rm -fr ./dist & babel ./src --out-dir ./dist -s inline --extensions \".ts,.js\"",
+    "prepublishOnly": "rm -fr ./dist & babel --config-file ./babel.prod.config.js ./src --out-dir ./dist -s inline --extensions \".ts,.js\"",
     "cypress:run": "cypress run",
     "test:e2e": "NODE_ENV=test start-test 6060 cypress:run && nyc report --reporter=json-summary",
     "test:unit": "NODE_ENV=test jest ./src/core --coverage && cat ./coverage/lcov.info | coveralls",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11098,10 +11098,10 @@ markdown-to-jsx@^6.10.3:
     prop-types "^15.6.2"
     unquote "^1.1.0"
 
-markdown-translatable@1.2.16:
-  version "1.2.16"
-  resolved "https://registry.yarnpkg.com/markdown-translatable/-/markdown-translatable-1.2.16.tgz#048624bb4762370db30030c4d0265b721c54f7e8"
-  integrity sha512-miTzfgoCCFwodkNN9EuUlGg2HoKZbJlYt1BqbqsfpT2jbXbu7jMPVB4d+Jj7wh3wyNSJzON4GqV4X90ke6Gt1w==
+markdown-translatable@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/markdown-translatable/-/markdown-translatable-1.3.1.tgz#29393f8650be38885c7991f2e2e661bbe9d000ae"
+  integrity sha512-oZieaVOCjxZISyGDvcpb3XsJsnPvKd4xCULFQawQ/L395EwGHFERG6gCH65b3w3HjkLEWhdPknWf1BLK6Mu6Tg==
   dependencies:
     deep-freeze "^0.0.1"
     md5 "^2.2.1"


### PR DESCRIPTION
## Describe what your pull request addresses
part of https://github.com/unfoldingword/gateway-edit/issues/228
- fix to remove coverage calcs from published module

## Test Instructions
- test with https://deploy-preview-265--gateway-edit.netlify.app/
- try add the following scripture urls to a scripture pane.  Make sure scripture actually shows up in scripture pane:
- [ ] `https://git.door43.org/unfoldingWord/en_ult`
- [ ] `https://git.door43.org/unfoldingWord/el-x-koine_ugnt/src/tag/v0.20`
- [ ] `https://door43.org/u/unfoldingWord/en_ult/`
- [ ] `https://git.door43.org/Door43-Catalog/en_ust.git`
- [ ] `git@git.door43.org:unfoldingWord/en_ult.git`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/gitea-react-toolkit/102)
<!-- Reviewable:end -->
