### PR TITLE
UseEdit custom hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.10.1-alpha",
+  "version": "1.11.0-rc0",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.10.0-rc.20",
+  "version": "1.10.0",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.11.0-rc0",
+  "version": "1.11.0-rc1",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "1.11.0-rc1",
+  "version": "1.11.0",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/src/components/file/useEdit.js
+++ b/src/components/file/useEdit.js
@@ -25,11 +25,6 @@ export default function useEdit({
   async function onSaveEdit(_branch) {
     try {
       if (content) {
-        console.log({ _branch, branch })
-        // if (branch == 'master' || _branch == 'master') {
-        //   throw new Error(`Should not save edits in master branch, branch = ${branch}`)
-        // }
-
         setState((prevState) => ({
           ...prevState,
           editResponse: null,

--- a/src/components/file/useEdit.js
+++ b/src/components/file/useEdit.js
@@ -25,9 +25,10 @@ export default function useEdit({
   async function onSaveEdit(_branch) {
     try {
       if (content) {
-        if (branch == 'master' || _branch == 'master') {
-          throw new Error(`Should not save edits in master branch, branch = ${branch}`)
-        }
+        console.log({ _branch, branch })
+        // if (branch == 'master' || _branch == 'master') {
+        //   throw new Error(`Should not save edits in master branch, branch = ${branch}`)
+        // }
 
         setState((prevState) => ({
           ...prevState,
@@ -36,23 +37,39 @@ export default function useEdit({
           isError: false,
         }))
   
-        const response = await updateContent({
-          sha,
-          repo,
-          owner,
-          config,
-          author,
-          content,
-          filepath,
-          message: _message,
-          // Use branch passed to function or branch passed to custom hook. 
-          branch: _branch || branch,
-        });
+        let response = null
+        
+        if (branch !== 'master' || _branch !== 'master') {
+          response = await updateContent({
+            sha,
+            repo,
+            owner,
+            config,
+            author,
+            content,
+            filepath,
+            message: _message,
+            // Use branch passed to function or branch passed to custom hook. 
+            branch: _branch || branch,
+          });
+        } else {
+          response = {
+            error: 'Attempted to save to master branch'
+          }
+
+          setState((prevState) => ({
+            ...prevState,
+            editResponse: response,
+          }))
+
+          return false
+        }
   
         setState((prevState) => ({
           ...prevState,
           editResponse: response,
         }))
+
         return true
       } else {
         console.warn('Content value is empty')

--- a/src/components/file/useEdit.js
+++ b/src/components/file/useEdit.js
@@ -25,6 +25,10 @@ export default function useEdit({
   async function onSaveEdit(_branch) {
     try {
       if (content) {
+        if (branch == 'master' || _branch == 'master') {
+          throw new Error(`Should not save edits in master branch, branch = ${branch}`)
+        }
+
         setState((prevState) => ({
           ...prevState,
           editResponse: null,


### PR DESCRIPTION

## Test Instructions

- [x] Open https://deploy-preview-277--gateway-edit.netlify.app/
- [x] Log in with your DCS account.
- [x] Choose English and test_org.
- [x] Translation academy and translation words should still be editable.
- [ ] In TranslationNotes OccurrenceNote, OccurrenceNumber, SupportReference, Original Quote should be editable.
- [ ] On blur, the scripture highlight should update when the Original Quote or OccurrenceNumber are edited.
- [ ] On blur, the TranslationAcademy article should update when the user edits the SupportReference.
- [x] Translation questions should be editable.
- [x] In Translation word list Original Quote and Occurrence field should be editable.
- [ ] Now change the org to test_org2 and repeat the steps.



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/gitea-react-toolkit/103)
<!-- Reviewable:end -->
