### PR TITLE
relocate saveCache function

### DIFF
--- a/src/components/file/useFile.js
+++ b/src/components/file/useFile.js
@@ -179,6 +179,12 @@ function useFile({
     update();
   }, [update, blobActions, onFilepath]);
 
+  const saveCache = useCallback(async (content) => {
+    if (onSaveCache) {
+      await onSaveCache({authentication, repository, branch, file, content});
+    }
+  }, [writeable, authentication, repository, branch, file, onSaveCache]);
+
   const save = useCallback(async (content) => {
     console.log("GRT save // will save file");
     await saveFile({
@@ -195,12 +201,6 @@ function useFile({
       }
     );
   }, [writeable, authentication, repository, branch, file, load, saveFile, saveCache]);
-
-  const saveCache = useCallback(async (content) => {
-    if (onSaveCache) {
-      await onSaveCache({authentication, repository, branch, file, content});
-    }
-  }, [writeable, authentication, repository, branch, file, onSaveCache]);
 
   const dangerouslyDelete = useCallback(async () => {
     if (writeable) {


### PR DESCRIPTION
The problem is in useFile.js. The code in develop branch shows this:
```js
  const save = useCallback(async (content) => {
    console.log("GRT save // will save file");
    await saveFile({
      authentication, repository, branch, file, content,
    }).then(
      // Empty cache if user has saved this file
      // (save() will not happen for "OFFLINE" system files)
      async() => {
        console.log("GRT save // will EMPTY cache");
        await saveCache(null); 
        
        console.log("GRT save // will load file");
        await load();
      }
    );
  }, [writeable, authentication, repository, branch, file, load, saveFile, saveCache]);

  const saveCache = useCallback(async (content) => {
    if (onSaveCache) {
      await onSaveCache({authentication, repository, branch, file, content});
    }
  }, [writeable, authentication, repository, branch, file, onSaveCache]);
```

The "saveCache" variable is used in the dependency list before it is defined on the following lines. The saveCache definition must be moved ahead of it first use. By doing that, it no longer crashes and I can now get to the login screen.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/gitea-react-toolkit/114)
<!-- Reviewable:end -->
