### PR TITLE
Delay creating branch until save is done

### DIFF
--- a/coverage/shields.json
+++ b/coverage/shields.json
@@ -1,1 +1,1 @@
-{"message":"46.08%","label":"Integration Tests","schemaVersion":1}
+{"message":"45.96%","label":"Integration Tests","schemaVersion":1}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/src/components/file/File.context.md
+++ b/src/components/file/File.context.md
@@ -29,7 +29,7 @@ function Component() {
     onRepository: setRepository,
     defaultOwner: authentication && authentication.user.name,
     defaultQuery: "",
-    branch: 'dimmy',
+    branch: 'testing',
   });
   const { state: file, actions: fileActions, component: fileComponent } = useFile({
     authentication,

--- a/src/components/file/File.context.md
+++ b/src/components/file/File.context.md
@@ -24,13 +24,16 @@ function Component() {
     onAuthentication: setAuthentication,
   });
   const { state: repo, component: repoComponent } = useRepository({
+    authentication,
     repository,
     onRepository: setRepository,
     defaultOwner: authentication && authentication.user.name,
     defaultQuery: "",
-    branch: 'master',
+    branch: 'dimmy',
   });
   const { state: file, actions: fileActions, component: fileComponent } = useFile({
+    authentication,
+    repository,
     filepath,
     onFilepath: setFilepath,
     create: false,

--- a/src/components/file/_create.md
+++ b/src/components/file/_create.md
@@ -41,7 +41,7 @@ function Component() {
     onRepository: setRepository,
     defaultOwner: authentication && authentication.user.name,
     defaultQuery: "",
-    branch: 'testing',
+    branch: 'dummy3',
   });
   const { state: file, component: fileComponent } = useFile({
     authentication,
@@ -49,6 +49,7 @@ function Component() {
     filepath,
     onFilepath: setFilepath,
     create: true,
+    delay: true,
   });
 
   return (!auth && authComponent) || (!repo && repoComponent) || fileComponent;

--- a/src/components/file/_create.md
+++ b/src/components/file/_create.md
@@ -41,7 +41,7 @@ function Component() {
     onRepository: setRepository,
     defaultOwner: authentication && authentication.user.name,
     defaultQuery: "",
-    branch: 'dummy3',
+    branch: 'testing',
   });
   const { state: file, component: fileComponent } = useFile({
     authentication,
@@ -49,7 +49,6 @@ function Component() {
     filepath,
     onFilepath: setFilepath,
     create: true,
-    delay: true,
   });
 
   return (!auth && authComponent) || (!repo && repoComponent) || fileComponent;

--- a/src/components/file/helpers.js
+++ b/src/components/file/helpers.js
@@ -1,5 +1,5 @@
 import {
-  get, updateContent, ensureContent, deleteContent, decodeBase64ToUtf8,
+  get, updateContent, ensureContent, deleteContent, decodeBase64ToUtf8, createContent,
 } from '../..';
 
 export const ensureFile = async ({
@@ -71,11 +71,17 @@ export const saveFile = async ({
   const { owner: { username: owner }, name: repo } = repository;
   const { path: filepath, sha } = file;
   const _message = message || `Edit '${filepath}' using '${tokenid}'`;
-
-  const response = await updateContent({
-    config, owner, repo, branch, filepath,
-    content, message: _message, author, sha,
-  });
+  let response;
+  try {
+    response = await updateContent({
+      config, owner, repo, branch, filepath,
+      content, message: _message, author, sha,
+    });
+  } catch {
+    response = await createContent({
+      config, owner, repo, branch, filepath, content, message: _message, author, sha
+    });
+  }
   return response;
 };
 

--- a/src/core/gitea-api/repos/contents/contents.ts
+++ b/src/core/gitea-api/repos/contents/contents.ts
@@ -142,7 +142,7 @@ export const updateContent = async ({
       contentObject = response.content;
     };
   } catch (error) {
-    // Allow original error to propogate.
+    // Allow original error to propagate.
     // This allows switching based on error messages above.
     throw error;
   };
@@ -175,12 +175,12 @@ export const ensureContent = async ({
 }: ModifyContentOptions): Promise<ContentObject> => {
   let contentObject: ContentObject;
 
-  try { // try to read the file
+  try {// try to read the file
     // NOTE: when a source file is fetched for translation, the following readConent
     // should always succeed since the file was selected from a UI which
     // is showing files that exist.
     //
-    // OTOH, if the file is the target this will return null (the first time), 
+    // OTOH, if the file is the target this will return null (the first time),
     // throwing the error. When the error is thrown, the catch will fire.
     contentObject = await readContent({
       owner, repo, ref: branch, filepath, config,
@@ -194,20 +194,19 @@ export const ensureContent = async ({
       onOpenValidation(filepath, _content,contentObject.html_url);
     }
   } catch {
-    try { // try to update the file in case it is in the default branch
-      // NOTE: if the file is in the master branch of the target
-      // the following readContent will succeed
-      // Otherwise it returns null; if null then the getContentFromFile
-      // will throw an error (probably from trying to decode null or
-      // if by url, a 404 is returned and get throws an error)
-      // In this case, the catch() will create the content from the source
-      // createContent will be called at some point during the update
-
+    try {
+      // try to read file from the default branch
+      // if it exists content will be returned without creating a new branch
       contentObject = await readContent({
         owner, repo, filepath, config,
       });
 
+      if (!contentObject) {
+        throw new Error('File does not exist in default branch');
+      }
+
     } catch { // try to create the file if it doesn't exist in default or new branch
+      // if branch does not exist yet, it will be created here.
       contentObject = await createContent({
         config, owner, repo, branch, filepath, content, message, author,
       });

--- a/src/core/gitea-api/repos/contents/contents.ts
+++ b/src/core/gitea-api/repos/contents/contents.ts
@@ -190,46 +190,29 @@ export const ensureContent = async ({
     // add on open validation checks here for source side or existing branch content
     //
     const _content:string = await getContentFromFile(contentObject);
-    let notices: string[] = [];
     if ( onOpenValidation ) {
-      notices = onOpenValidation(filepath, _content,contentObject.html_url);
+      onOpenValidation(filepath, _content,contentObject.html_url);
     }
   } catch {
     try { // try to update the file in case it is in the default branch
       // NOTE: if the file is in the master branch of the target
-      // the following readConcent will succeed
+      // the following readContent will succeed
       // Otherwise it returns null; if null then the getContentFromFile
       // will throw an error (probably from trying to decode null or
       // if by url, a 404 is returned and get throws an error)
       // In this case, the catch() will create the content from the source
-      // the "updateContent" will cause the existing target content in master
-      // to be used. createContent will be called at some point during the update
-      const _contentObject = await readContent({
+      // createContent will be called at some point during the update
+
+      contentObject = await readContent({
         owner, repo, filepath, config,
       });
-      //
-      // add on open validation checks here for when target repo has data, but there is no user branch
-      //
-      // the below can throw an error, so it will go to the catch for create to be done
-      const _content = await getContentFromFile(_contentObject);
-      let notices: string[] = [];
-      if ( onOpenValidation ) {
-        notices = onOpenValidation(filepath, _content,_contentObject.html_url);
-      }
-      if ( notices.length === 0 ) {
-        // only update if no notices
-        contentObject = await updateContent({
-          config, owner, repo, branch, filepath, content: _content, message, author, sha: _contentObject.sha,
-        });
-      } else {
-        contentObject = _contentObject;
-      }
+
     } catch { // try to create the file if it doesn't exist in default or new branch
       contentObject = await createContent({
         config, owner, repo, branch, filepath, content, message, author,
       });
-    };
-  };
+    }
+  }
 
   return contentObject;
 };

--- a/src/core/gitea-api/repos/contents/createContent.md
+++ b/src/core/gitea-api/repos/contents/createContent.md
@@ -6,18 +6,18 @@ import { Core, createContent } from 'gitea-react-toolkit';
 
 const props = {
   config: {
-    server: 'https://bg.door43.org',
+    server: 'https://qa.door43.org',
     tokenid: 'PlaygroundTesting',
   },
-  owner: 'klappy',
-  repo: 'blank',
-  branch: 'testing',
+  owner: 'unfoldingWord',
+  repo: 'en_obs',
+  branch: 'cecils-branch',
   filepath: 'README.md',
   content: 'Testing createContent',
   message: 'Testing createContent via Gitea-React-Toolkit',
   author: {
-    email: "user@example.com",
-    username: "user",
+    email: "cecil.new@gmail.com",
+    username: "cecil.new",
   },
 };
 


### PR DESCRIPTION
For https://github.com/unfoldingWord/tc-create-app/issues/888

Turns out just a few critical line changes and it seems to work. I think we may want to only use this new behavior if a new option is passed to it. I'm not sure all consumers of this library will want to the new behavior.

Testing instructions in styleguidist:
1. Select File Crude -> Create for sidebar or go to http://localhost:6060/#/File%20CRUD?id=section-create
2. Login and choose a repository. I testing with superdav42/hbo_obs
3. Enter filePath of a file that exists on master such as README.md
4. You should see contents of README.md from master but no new branch will be created which you can verify at https://bg.door43.org/superdav42/hbo_obs/branches
5. Add new content to README.md and click save button.
6. New branch will be created at https://bg.door43.org/superdav42/hbo_obs/branches and contain the new content in README.md

Feel free to change branch name in src/components/file/_create.md:44 to ensure it works as expected.

I'll investigate how it's working in tc-create-app but if can verify it works in styleguidist that would help.