### PR TITLE
Do not create user branch when working with new file

### DIFF
--- a/coverage/shields.json
+++ b/coverage/shields.json
@@ -1,1 +1,1 @@
-{"message":"45.86%","label":"Integration Tests","schemaVersion":1}
+{"message":"45.85%","label":"Integration Tests","schemaVersion":1}

--- a/src/components/file/helpers.js
+++ b/src/components/file/helpers.js
@@ -48,8 +48,12 @@ export const getContentFromFile = async (file) => {
   } = file;
   let _content;
 
-  if (content && encoding === 'base64') {
-    _content = decodeBase64ToUtf8(content);
+  if (content) {
+    if ('base64' === encoding) {
+      _content = decodeBase64ToUtf8(content);
+    } else {
+      _content = content;
+    }
   } else if (!content && download_url) {
     _content = await get({ url: download_url, noCache: true });
   } else if (!content && git_url) {

--- a/src/components/file/useFile.js
+++ b/src/components/file/useFile.js
@@ -20,7 +20,7 @@ function useFile({
   repository,
   filepath,
   onFilepath,
-  defaultContent: _defaultContent,
+  defaultContent,
   config: _config,
   create=false,
   onOpenValidation,
@@ -29,7 +29,6 @@ function useFile({
   onConfirmClose,
   releaseFlag,
 }) {
-  const [defaultContent, setDefaultContent] = useState(_defaultContent)
   const [file, setFile] = useState();
   const [isChanged, setIsChanged] = useState(false);
   const [blob, setBlob] = useState();
@@ -114,7 +113,6 @@ function useFile({
     branch: _branch, filepath: _filepath, defaultContent: _defaultContent, onOpenValidation,
   }) => {
     if (config && repository) {
-      setDefaultContent(_defaultContent);
       const _file = await ensureFile({
         authentication,
         config,

--- a/src/components/file/useFile.js
+++ b/src/components/file/useFile.js
@@ -20,7 +20,7 @@ function useFile({
   repository,
   filepath,
   onFilepath,
-  defaultContent,
+  defaultContent: _defaultContent,
   config: _config,
   create=false,
   onOpenValidation,
@@ -29,6 +29,7 @@ function useFile({
   onConfirmClose,
   releaseFlag,
 }) {
+  const [defaultContent, setDefaultContent] = useState(_defaultContent)
   const [file, setFile] = useState();
   const [isChanged, setIsChanged] = useState(false);
   const [blob, setBlob] = useState();
@@ -113,6 +114,7 @@ function useFile({
     branch: _branch, filepath: _filepath, defaultContent: _defaultContent, onOpenValidation,
   }) => {
     if (config && repository) {
+      setDefaultContent(_defaultContent);
       const _file = await ensureFile({
         authentication,
         config,

--- a/src/core/gitea-api/repos/contents/contents.ts
+++ b/src/core/gitea-api/repos/contents/contents.ts
@@ -40,6 +40,7 @@ interface ContentObject {
   sha: string;
   content: string;
   html_url: string;
+  name?: string;
 }
 
 export const payload = ({
@@ -208,6 +209,7 @@ export const ensureContent = async ({
     } catch {
       // use content object unconnected to branch or repo.
       contentObject = {
+        name: filepath.slice(filepath.lastIndexOf('/')+1),
         content: content || '',
         path: filepath,
         sha: 'new',

--- a/src/core/gitea-api/repos/contents/contents.ts
+++ b/src/core/gitea-api/repos/contents/contents.ts
@@ -40,7 +40,7 @@ interface ContentObject {
   sha: string;
   content: string;
   html_url: string;
-  name?: string;
+  name: string;
 }
 
 export const payload = ({

--- a/src/core/gitea-api/repos/contents/contents.ts
+++ b/src/core/gitea-api/repos/contents/contents.ts
@@ -207,13 +207,13 @@ export const ensureContent = async ({
       }
 
     } catch {
-      // use content object unconnected to branch or repo.
+      // create contentObject directly when unconnected to branch or repo.
       contentObject = {
         name: filepath.slice(filepath.lastIndexOf('/')+1),
         content: content || '',
         path: filepath,
         sha: 'new',
-        html_url:'',
+        html_url: '',
       }
     }
   }

--- a/src/core/gitea-api/repos/contents/contents.ts
+++ b/src/core/gitea-api/repos/contents/contents.ts
@@ -205,11 +205,14 @@ export const ensureContent = async ({
         throw new Error('File does not exist in default branch');
       }
 
-    } catch { // try to create the file if it doesn't exist in default or new branch
-      // if branch does not exist yet, it will be created here.
-      contentObject = await createContent({
-        config, owner, repo, branch, filepath, content, message, author,
-      });
+    } catch {
+      // use content object unconnected to branch or repo.
+      contentObject = {
+        content: content || '',
+        path: filepath,
+        sha: 'new',
+        html_url:'',
+      }
     }
   }
 


### PR DESCRIPTION
Follow up for https://github.com/unfoldingWord/gitea-react-toolkit/pull/138

Previous changes **did**  create a user branch if the file requested did not exist in the master branch. 

This improved on that so a user branch will **NOT** be created until the user saves a file.

Turns out it was easy enough to just create a contectObject without fetching it from anywhere. Seems to be working for me but I still don't have access to the usual translator repositories. 
