### PR TITLE
Always run validation checks

### DIFF
--- a/src/core/gitea-api/repos/contents/contents.ts
+++ b/src/core/gitea-api/repos/contents/contents.ts
@@ -187,13 +187,6 @@ export const ensureContent = async ({
       owner, repo, ref: branch, filepath, config,
     });
     if (!contentObject) throw new Error('File does not exist in branch');
-    //
-    // add on open validation checks here for source side or existing branch content
-    //
-    const _content:string = await getContentFromFile(contentObject);
-    if ( onOpenValidation ) {
-      onOpenValidation(filepath, _content,contentObject.html_url);
-    }
   } catch {
     try {
       // try to read file from the default branch
@@ -217,6 +210,12 @@ export const ensureContent = async ({
       }
     }
   }
-
+  //
+  // add on open validation checks here for source side or existing branch content
+  //
+  const _content:string = await getContentFromFile(contentObject);
+  if ( onOpenValidation ) {
+    onOpenValidation(filepath, _content,contentObject.html_url);
+  }
   return contentObject;
 };


### PR DESCRIPTION
Fixes https://app.zenhub.com/workspaces/tc-create-workspace-5f049cdbfa88090016bf043e/issues/unfoldingword/tc-create-app/1343

Test: Open en_tn 2KI. Should see validation errors instead of whitepage and errors in console. 