### PR TITLE
Fix No Warning when closing file chip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "2.2.0",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/src/components/application-bar/ApplicationBar.js
+++ b/src/components/application-bar/ApplicationBar.js
@@ -47,7 +47,7 @@ function ApplicationBar({
           </Typography>
           <div className={classes.grow} />
           {buttons}
-          {!hideRepositoryMenu ? <RepositoryMenu repo={repo} /> : null}
+          {!hideRepositoryMenu ? <RepositoryMenu repo={repo} file={file} /> : null}
           <UserMenu auth={auth} />
         </Toolbar>
       </AppBar>

--- a/src/components/application-bar/RepositoryMenu.js
+++ b/src/components/application-bar/RepositoryMenu.js
@@ -32,10 +32,10 @@ function RepositoryMenu({
     full_name,
   } = repository || {};
 
-  const _onDelete = useCallback(() => {
+  const _onDelete = useCallback(async () => {
     if (actions?.close) {
       if (fileActions?.onConfirmClose) {
-        if (fileActions.onConfirmClose())
+        if (await fileActions.onConfirmClose())
         {
           actions.close();
         }

--- a/src/components/application-bar/RepositoryMenu.md
+++ b/src/components/application-bar/RepositoryMenu.md
@@ -44,3 +44,42 @@ const [repository, setRepository] = React.useState();
   </AuthenticationContextProvider>
 </Paper>
 ```
+
+Warning to close.
+
+```js
+import { Paper } from '@material-ui/core';
+import { RepositoryMenu, AuthenticationContextProvider, RepositoryContextProvider, FileContextProvider } from 'gitea-react-toolkit';
+
+const repository = {
+  server: 'it',
+  name: 'test_repo',
+  avatar_url: 'about:blank',
+  owner: 'me',
+  full_name: 'The Test Repo',
+};
+
+<Paper>
+  <AuthenticationContextProvider>
+    <RepositoryContextProvider
+      repository={repository}
+      urls={[
+        "https://qa.door43.org/unfoldingWord/en_ta",
+        "https://qa.door43.org/unfoldingWord/en_tw",
+      ]}
+    >
+      <FileContextProvider
+          onConfirmClose={() => {
+            return new Promise(function (resolve, reject) {
+                let confirmed = window.confirm('Es Verdad?');
+                return confirmed ? resolve(true) : reject(false);
+            })
+          } }
+          filepath="it.tsv"
+        >
+        <RepositoryMenu />
+      </FileContextProvider>
+    </RepositoryContextProvider>
+  </AuthenticationContextProvider>
+</Paper>
+```


### PR DESCRIPTION
For https://github.com/unfoldingWord/tc-create-app/issues/1450

* We need to pass the file as a prop since tc-create-app is not using the FileContextProvider. 
*   onConfirmClose can be a promise so use async await

Test:
1. Open styleguidest to http://localhost:6060/#/Application%20Bar%20?id=repositorymenu
2. Scroll to new example "Warning to close."
3. Try to close the chip
4. obverse confirm popup