### PR TITLE
bugfix 564 / fix for 500 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "2.4.0-beta",
+  "version": "2.4.0",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitea-react-toolkit",
-  "version": "2.3.0",
+  "version": "2.4.0-beta",
   "license": "MIT",
   "description": "A Gitea API React Toolkit Component Library",
   "homepage": "https://gitea-react-toolkit.netlify.com/",

--- a/src/components/file/useEdit.js
+++ b/src/components/file/useEdit.js
@@ -46,18 +46,20 @@ export default function useEdit({
    * @async
    * @param {string} _branch - branch name to save content to 
    * @param {string} newContent - Stringified content to be saved to DCS
+   * @param {string|null} fileSha - optional file sha to be used, if not passed then sha will be used
    * @returns {Promise<Object>} - Response after saving the content.
    */
-  async function saveContent(_branch, newContent) {
+  async function saveContent(_branch, newContent, fileSha = null) {
     setState((prevState) => ({
       ...prevState,
       editResponse: null,
       isEditing: true,
       isError: false,
     }))
-    
+
+    const _sha = fileSha || sha
     const response = await updateContent({
-      sha,
+      sha: _sha,
       repo,
       owner,
       config,
@@ -83,17 +85,18 @@ export default function useEdit({
    * @async
    * @param {string} _branch - branch name to save content to 
    * @param {string} newContent - optional Stringified content to be saved to DCS, if not passed then value in content will be used
+   * @param {string|null} fileSha - optional file sha to be used, if not passed then sha will be used
    * @returns {Promise<boolean>} - Returns true if successful, otherwise false.
    */
-  async function onSaveEdit(_branch, newContent='') {
+  async function onSaveEdit(_branch, newContent='', fileSha = null) {
     try {
       if (newContent) {
         if (content && content === newContent) {
           return true
         }
-        await saveContent(_branch, newContent)
+        await saveContent(_branch, newContent, fileSha)
       } else if (content) {
-        await saveContent(_branch, content)
+        await saveContent(_branch, content, fileSha)
       } else {
         console.warn('Content and newContent values are empty')
       }

--- a/src/components/file/useEdit.js
+++ b/src/components/file/useEdit.js
@@ -82,7 +82,7 @@ export default function useEdit({
    * during the save.
    * @async
    * @param {string} _branch - branch name to save content to 
-   * @param {string} newContent - Stringified content to be saved to DCS
+   * @param {string} newContent - optional Stringified content to be saved to DCS, if not passed then value in content will be used
    * @returns {Promise<boolean>} - Returns true if successful, otherwise false.
    */
   async function onSaveEdit(_branch, newContent='') {
@@ -109,10 +109,20 @@ export default function useEdit({
     }
   }
 
-  async function onSaveEditPatch(_branch) {
+  /**
+   * Saves a patch to given branch and catches any errors that happen
+   * during the save.
+   * @async
+   * @param {string} _branch - branch name to save content to
+   * @param {string} newContent - optional patched content to be saved to DCS, if not passed then value in content will be used
+   * @param {string|null} fileSha - optional file sha to be used, if not passed then sha will be used
+   * @returns {Promise<boolean>} - Returns true if successful, otherwise false.
+   */
+  async function onSaveEditPatch(_branch, newContent= '', fileSha = null) {
     try {
-      // content is the updated string or dirty content.
-      if (content) {
+      const _content = newContent || content
+      const _sha = fileSha || sha
+      if (_content) {
         // clear state to remove left over state from a previous edit.
         setState((prevState) => ({
           ...prevState,
@@ -122,13 +132,13 @@ export default function useEdit({
         }))
 
         const response = await patchContent({
-          sha,
+          sha: _sha,
           repo,
           owner,
           config,
           author,
           email,
-          content,
+          content: _content,
           filepath,
           message: _message,
           // Use branch passed to function or branch passed to custom hook. 


### PR DESCRIPTION
#### Describe what your pull request addresses (Please include relevant issue numbers):
- Part of https://github.com/unfoldingWord/gateway-edit/issues/564
- add file sha as optional parameter to useEdit save functions
- add optional new content parameter to useEdit.onSaveEditPatch()

#### Please include detailed Test instructions for your pull request:
- test with https://deploy-preview-583--gateway-edit.netlify.app/
- should not see any problems saving scripture, particularly no 500 errors.  401 authentication errors are in another issue.

#### Standard Test Instructions for PR Review Process:

- [ ] Double check unit tests that have been written
- [ ] Check for documentation for code changes
- [ ] Is the repo documentation accurate/appropriate?
  - [ ] Check Stylguidist if applicable
  - [ ] Check readme for correct information about the feature being worked on
- [ ] Check that there are not inadvertent commits 
- [ ] Checkout the branch locally and ensure that app runs as expected
  - [ ] Ensure tests pass
  - [ ] Open and watch the console for errors
  - [ ] Make sure all actions perform as expected
  - [ ] Import and Load a new Project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Switch project to an existing project
  - [ ] Load a tool and perform basic actions
  - [ ] Switch tools and perform basic actions
  - [ ] Next time reverse the order of importing after loading an existing project
- [ ] Reviewer should double check the DoD in the ISSUE, including the “spirit” of the story
